### PR TITLE
Migrate `xtask` to rust 2018 edition

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xtask"
 version = "0.0.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,8 +1,3 @@
-extern crate clap;
-extern crate failure;
-extern crate heck;
-extern crate itertools;
-
 use clap::{App, Arg, SubCommand};
 use itertools::Itertools;
 use std::fs;
@@ -106,7 +101,7 @@ fn get_tests(verify: bool) -> Result<()> {
         let mut res = HashMap::new();
         let comment_blocks = s
             .lines()
-            .map(str::trim_left)
+            .map(str::trim_start)
             .group_by(|line| line.starts_with("//"));
 
         'outer: for (is_comment, block) in comment_blocks.into_iter() {


### PR DESCRIPTION
Heck, that was easy :D