### PR TITLE
Migrate `tom_syntax` and `tom` to rust 2018 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,6 +714,9 @@ name = "serde"
 version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"

--- a/crates/tom/Cargo.toml
+++ b/crates/tom/Cargo.toml
@@ -2,10 +2,11 @@
 name = "tom"
 version = "0.1.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
+edition = "2018"
 publish = false
 
 [dependencies]
-serde = "1.0.71"
+serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0.71"
 url_serde = "0.2.0"
 crossbeam-channel = "0.2.6"

--- a/crates/tom/src/main.rs
+++ b/crates/tom/src/main.rs
@@ -1,18 +1,3 @@
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate url_serde;
-extern crate gen_lsp_server;
-extern crate languageserver_types;
-#[macro_use]
-extern crate failure;
-extern crate crossbeam_channel;
-extern crate superslice;
-extern crate tom_syntax;
-extern crate flexi_logger;
-#[macro_use]
-extern crate log;
-
 mod line_index;
 mod req;
 mod caps;
@@ -26,8 +11,8 @@ use languageserver_types::{
 };
 use gen_lsp_server::{run_server, stdio_transport, handle_shutdown, RawMessage, RawResponse, RawNotification};
 use flexi_logger::{Logger, Duplicate};
-use tom_syntax::{TomlDoc, ast, TextRange, TextUnit, symbol::*};
-
+use tom_syntax::{TomlDoc, TextRange, TextUnit, symbol::*};
+use failure::format_err;
 
 use line_index::{LineIndex, LineCol};
 

--- a/crates/tom/src/req.rs
+++ b/crates/tom/src/req.rs
@@ -1,6 +1,6 @@
 use languageserver_types::{
-    Url, Range, Position, TextDocumentIdentifier,
-    request::{GotoDefinition, GotoDefinitionResponse, Request},
+    Url, Range, TextDocumentIdentifier,
+    request::Request,
     notification::{Notification},
 };
 

--- a/crates/tom/src/req.rs
+++ b/crates/tom/src/req.rs
@@ -1,3 +1,4 @@
+use serde::{Serialize, Deserialize};
 use languageserver_types::{
     Url, Range, TextDocumentIdentifier,
     request::Request,

--- a/crates/tom_syntax/Cargo.toml
+++ b/crates/tom_syntax/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tom_syntax"
 version = "0.0.1"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
+edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/tom"
 description = """

--- a/crates/tom_syntax/src/ast/generated.rs
+++ b/crates/tom_syntax/src/ast/generated.rs
@@ -1,4 +1,4 @@
-use {
+use crate::{
     SyntaxNode, SyntaxNodeRef, AstNode, AstChildren, TreeRoot, RefRoot, OwnedRoot, TomTypes,
     symbol::*,
 };

--- a/crates/tom_syntax/src/ast/mod.rs
+++ b/crates/tom_syntax/src/ast/mod.rs
@@ -2,7 +2,7 @@ mod generated;
 
 use std::borrow::Cow;
 
-use ::{ast, AstNode, AstChildren};
+use crate::{ast, AstNode, AstChildren};
 pub use self::generated::*;
 
 pub trait EntryOwner<'a>: AstNode<'a> {

--- a/crates/tom_syntax/src/lib.rs
+++ b/crates/tom_syntax/src/lib.rs
@@ -1,14 +1,4 @@
-extern crate m_lexer;
-extern crate itertools;
-extern crate text_unit;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate uncover;
-extern crate drop_bomb;
-extern crate rowan;
-
-define_uncover_macros!(enable_if(cfg!(debug_assertions)));
+uncover::define_uncover_macros!(enable_if(cfg!(debug_assertions)));
 
 mod chunked_text;
 mod rtree;
@@ -31,7 +21,7 @@ use std::{
 pub use rowan::{SmolStr, TextRange, TextUnit, WalkEvent};
 // pub use model::{Item, Map};
 pub use rtree::{SyntaxNode, SyntaxNodeRef, RefRoot, OwnedRoot, SyntaxNodeChildren, TreeRoot, TomTypes};
-pub(crate) use rtree::{GreenBuilder};
+pub(crate) use rtree::GreenBuilder;
 pub(crate) use chunked_text::ChunkedText;
 
 

--- a/crates/tom_syntax/src/parser/grammar.rs
+++ b/crates/tom_syntax/src/parser/grammar.rs
@@ -1,5 +1,5 @@
 use drop_bomb::DebugDropBomb;
-use {parser::Parser, symbol::*, Symbol};
+use crate::{parser::Parser, symbol::*, Symbol};
 
 struct Mark {
     symbol: Symbol,

--- a/crates/tom_syntax/src/parser/lexer.rs
+++ b/crates/tom_syntax/src/parser/lexer.rs
@@ -1,6 +1,7 @@
 use m_lexer::{Lexer, LexerBuilder, TokenKind};
+use lazy_static::lazy_static;
 
-use {symbol, Symbol, TextRange, TextUnit};
+use crate::{symbol, Symbol, TextRange, TextUnit};
 
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct Token {

--- a/crates/tom_syntax/src/parser/mod.rs
+++ b/crates/tom_syntax/src/parser/mod.rs
@@ -1,7 +1,7 @@
 mod grammar;
 mod lexer;
 
-use ::{
+use crate::{
     symbol::*,
     SyntaxNode, GreenBuilder, Symbol, SmolStr, TextRange,
     SyntaxError,

--- a/crates/tom_syntax/src/rtree.rs
+++ b/crates/tom_syntax/src/rtree.rs
@@ -5,7 +5,7 @@ use std::{
 
 use rowan::{Types, WalkEvent, LeafAtOffset};
 
-use ::{TextRange, TextUnit, Symbol, SyntaxError, ChunkedText};
+use crate::{TextRange, TextUnit, Symbol, SyntaxError, ChunkedText};
 
 
 pub use rowan::TreeRoot;

--- a/crates/tom_syntax/src/symbol/mod.rs
+++ b/crates/tom_syntax/src/symbol/mod.rs
@@ -2,7 +2,7 @@ mod generated;
 
 use std::{fmt, num::NonZeroU8};
 
-use Symbol;
+use crate::Symbol;
 
 pub use self::generated::*;
 

--- a/crates/tom_syntax/src/validator.rs
+++ b/crates/tom_syntax/src/validator.rs
@@ -1,4 +1,4 @@
-use {
+use crate::{
     SyntaxNodeRef, SyntaxError, TextRange, TomlDoc, ChunkedText,
     ast,
 };

--- a/crates/tom_syntax/tests/suite/ast.rs
+++ b/crates/tom_syntax/tests/suite/ast.rs
@@ -1,5 +1,5 @@
 use tom_syntax::ast;
-use ::{find, toml};
+use crate::{find, toml};
 
 #[test]
 fn string_escaping_trivial() {

--- a/crates/tom_syntax/tests/suite/dir.rs
+++ b/crates/tom_syntax/tests/suite/dir.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use tom_syntax::{TomlDoc};
-use util::{print_difference, test_data_dir};
+use crate::util::{print_difference, test_data_dir};
 
 enum ExpectErrors {
     Yes,

--- a/crates/tom_syntax/tests/suite/main.rs
+++ b/crates/tom_syntax/tests/suite/main.rs
@@ -1,10 +1,3 @@
-extern crate difference;
-// #[macro_use]
-extern crate tom_syntax;
-#[macro_use]
-extern crate lazy_static;
-// extern crate serde_json;
-
 mod ast;
 mod dir;
 // mod edit;
@@ -20,6 +13,7 @@ use std::{
 };
 use util::{test_data_dir};
 use tom_syntax::{AstNode, TomlDoc};
+use lazy_static::lazy_static;
 
 #[test]
 fn simple_bench() {


### PR DESCRIPTION
Huh, this one was not complicated too