### PR TITLE
Fix gen ast: prepend crate:: in generated code

### DIFF
--- a/xtask/src/gen_ast.rs
+++ b/xtask/src/gen_ast.rs
@@ -147,7 +147,7 @@ pub fn gen_ast() -> String {
             buff.push_str("\n");
         }};
     }
-    ln!("use {{");
+    ln!("use crate::{{");
     ln!("SyntaxNode, SyntaxNodeRef, AstNode, AstChildren, TreeRoot, RefRoot, OwnedRoot, TomTypes,");
     ln!("symbol::*,");
     ln!("}};");


### PR DESCRIPTION
This is needed to obey to rust 2018 edition imports style