### PR TITLE
use correct branch name for cargo-deny-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: EmbarkStudios/cargo-deny-action@master
+      - uses: EmbarkStudios/cargo-deny-action@main
 
   rust:
     name: Rust


### PR DESCRIPTION
EmbarkStudios/cargo-deny-action swapped from master to main